### PR TITLE
Fixes #1

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -1,7 +1,6 @@
 ---
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
-@charset "utf-8";
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import
         "base"


### PR DESCRIPTION
Info from
[FontSpring](http://www.fontspring.com/support/troubleshooting/webfonts-
are-not-loading-in-safari) indicates that Safari fails to properly load
fonts with multiple `@charset “UTF-8”` declarations.
