### PR TITLE
Resolves #132

### DIFF
--- a/_data/forms.yml
+++ b/_data/forms.yml
@@ -2,5 +2,3 @@
   url: /files/registration_2015.pdf
 - name: Constitution
   url: /files/constitution_2015.pdf
-- name: OrgSync Forms
-  url: https://orgsync.com/93190/forms

--- a/join.html
+++ b/join.html
@@ -51,11 +51,6 @@ permalink: /join/
 
                 <section>
                     <p>
-                        The OrgSync forms must be completed online, and they include your proof of insurance
-                        and assumption of risk forms. Be sure to sign in with your campus ID once you get to
-                        the website!
-                    </p>
-                    <p>
                         The tryout form of previous years has been replaced with a much simpler form. Just
                         show up to practice and an officer will explain the procedure to you!
                     </p>


### PR DESCRIPTION
Decided to remove the OrgSync forms from the website, since they’re
detailed in the Registration Packet.
